### PR TITLE
Support `ahocorasick-rs` v10, add `kind` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.14.0
+
+* Upgraded to `aho-corasick` v1.0.
+* Exposed the choice between DFA, non-contiguous NFA, and contiguous NFA implementations.
+
 ## 0.13.0
 
 * Use less memory when constructing an instance.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bce8d450891e3b36f85a2230cec441fddd60e0c455b61b15bb3ffba955ca85"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -39,21 +39,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "indoc"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "parking_lot"
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
@@ -105,18 +105,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd4149c8c3975099622b4e1962dac27565cf5663b76452c3e2b66e0b6824277"
+checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd09fe469834db21ee60e0051030339e5d361293d8cb5ec02facf7fdcf52dbf"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c427c9a96b9c5b12156dbc11f76b14f49e9aae8905ca783ea87c249044ef137"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b822bbba9d60630a44d2109bc410489bb2f439b33e3a14ddeb8a40b378a7c4"
+checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ae898104f7c99db06231160770f3e40dad6eb9021daddc0fedfa3e41dff10a"
+checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -198,15 +198,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -215,61 +215,84 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unindent"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
+checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "git+https://github.com/BurntSushi/aho-corasick.git?branch=master#070de2a99c2dfd666dc8a071588ca3579d9ef7ee"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bce8d450891e3b36f85a2230cec441fddd60e0c455b61b15bb3ffba955ca85"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "aho-corasick"
 version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+source = "git+https://github.com/BurntSushi/aho-corasick.git?branch=master#070de2a99c2dfd666dc8a071588ca3579d9ef7ee"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "ahocorasick_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-aho-corasick = "0.7"
+aho-corasick = {git = "https://github.com/BurntSushi/aho-corasick.git", branch = "master"}
 
 [dependencies.pyo3]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "ahocorasick_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-aho-corasick = {git = "https://github.com/BurntSushi/aho-corasick.git", branch = "master"}
+aho-corasick = "1.0"
 
 [dependencies.pyo3]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can control the behavior by using the `store_patterns` keyword argument to `
 
 ### Algorithm implementations: trading construction speed, memory, and performance
 
-Choose the type of underlying automaton to use.
+You can choose the type of underlying automaton to use, with different performance tradeoffs.
 
 The underlying Rust library supports [four choices](https://docs.rs/aho-corasick/latest/aho_corasick/struct.AhoCorasickBuilder.html#method.kind), which are exposed:
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,25 @@ You can control the behavior by using the `store_patterns` keyword argument to `
   If this uses large amounts of memory this might actually slow things down due to pressure on the CPU memory cache, and/or the performance benefit might be overwhelmed by the algorithm's search time.
 * ``AhoCorasick(..., store_patterns=False)``: Don't keep references to the patterns, saving some memory but potentially slowing down ``find_matches_as_strings()``, especially when there are only a small number of patterns and you are searching a small haystack.
 
+### Kind
+
+Choose the type of underlying automaton to use.
+
+The underlying Rust library supports [four choices](https://docs.rs/aho-corasick/latest/aho_corasick/struct.AhoCorasickBuilder.html#method.kind), which are exposed:
+
+* `KIND_NONCONTIGUOUS_NFA`: A noncontiguous NFA is the fastest to be built, has moderate memory usage and is typically the slowest to execute a search.
+* `KIND_CONTIGUOUS_NFA`: A contiguous NFA is a little slower to build than a noncontiguous NFA, has excellent memory usage and is typically a little slower than a DFA for a search.
+* `KIND_DFA`: A DFA is very slow to build, uses exorbitant amounts of memory, but will typically execute searches the fastest.
+* `None` instructs the searcher to choose the “best” Aho-Corasick implementation.
+
+The default choice is `KIND_DFA` since expensive setup compensated by fast batch operations is the standard Python tradeoff.
+
+```python
+>>> ac = AhoCorasick(["disco", "disc"], kind=KIND_CONTIGUOUS_NFA)
+```
+
 ## Implementation details <a name="implementation"></a>
 
-* The underlying Rust library supports two implementations, one oriented towards reducing memory usage and construction time (NFA), the latter towards faster matching (DFA).
-  The Python wrapper only exposes the DFA version, since expensive setup compensated by fast batch operations is the standard Python tradeoff.
 * Matching releases the GIL, to enable concurrency.
 * Not all features from the underlying library are exposed; if you would like additional features, please [file an issue](https://github.com/g-research/ahocorasick_rs/issues/new) or submit a PR.
 

--- a/README.md
+++ b/README.md
@@ -144,21 +144,21 @@ You can control the behavior by using the `store_patterns` keyword argument to `
   If this uses large amounts of memory this might actually slow things down due to pressure on the CPU memory cache, and/or the performance benefit might be overwhelmed by the algorithm's search time.
 * ``AhoCorasick(..., store_patterns=False)``: Don't keep references to the patterns, saving some memory but potentially slowing down ``find_matches_as_strings()``, especially when there are only a small number of patterns and you are searching a small haystack.
 
-### Kind
+### Algorithm implementations: trading construction speed, memory, and performance
 
 Choose the type of underlying automaton to use.
 
 The underlying Rust library supports [four choices](https://docs.rs/aho-corasick/latest/aho_corasick/struct.AhoCorasickBuilder.html#method.kind), which are exposed:
 
-* `KIND_NONCONTIGUOUS_NFA`: A noncontiguous NFA is the fastest to be built, has moderate memory usage and is typically the slowest to execute a search.
-* `KIND_CONTIGUOUS_NFA`: A contiguous NFA is a little slower to build than a noncontiguous NFA, has excellent memory usage and is typically a little slower than a DFA for a search.
-* `KIND_DFA`: A DFA is very slow to build, uses exorbitant amounts of memory, but will typically execute searches the fastest.
-* `None` instructs the searcher to choose the “best” Aho-Corasick implementation.
+* `None` uses a heuristic to choose the "best" Aho-Corasick implementation for the given patterns.
+* `Implementation.NoncontiguousNFA`: A noncontiguous NFA is the fastest to be built, has moderate memory usage and is typically the slowest to execute a search.
+* `Implementation.ContiguousNFA`: A contiguous NFA is a little slower to build than a noncontiguous NFA, has excellent memory usage and is typically a little slower than a DFA for a search.
+* `Implementation.DFA`: A DFA is very slow to build, uses exorbitant amounts of memory, but will typically execute searches the fastest.
 
-The default choice is `KIND_DFA` since expensive setup compensated by fast batch operations is the standard Python tradeoff.
+The default choice is `Implementation.DFA` since expensive setup compensated by fast batch operations is the standard Python tradeoff.
 
 ```python
->>> ac = AhoCorasick(["disco", "disc"], kind=KIND_CONTIGUOUS_NFA)
+>>> ac = AhoCorasick(["disco", "disc"], implementation=Implementation.NoncontiguousNFA)
 ```
 
 ## Implementation details <a name="implementation"></a>

--- a/benchmarks/test_comparison.py
+++ b/benchmarks/test_comparison.py
@@ -18,7 +18,7 @@ with open(os.path.join(os.path.dirname(__file__), "names.txt")) as f:
     PATTERNS_LONG = [line.strip().lower() for line in f if len(line.strip()) > 4]
 
 
-# 90% no matches, 10% with 1 match, about 70 characters
+# 90% no matches, 10% with 1 match, about 600 characters
 def make_haystacks_long():
     line = "No one who had ever seen {} in her infancy would have supposed her born to be an heroine. Her situation in life, the character of her father and mother, her own person and disposition, were all equally against her. Her father was a clergyman, without being neglected, or poor, and a very respectable man, though his name was whatevs—and he had never been handsome. He had a considerable independence besides two good livings—and he was not in the least addicted to locking up his daughters. Her mother was a woman of useful plain sense, with a good temper, and, what is more remarkable, with a good constitution {}.".lower()
     result = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,8 @@ impl PyAhoCorasick {
         });
         Ok(Self {
             ac_impl: AhoCorasickBuilder::new()
-                .dfa(true) // DFA results in faster matches
+                // TODO consider noncontiguous, and/or auto mode; need to benchmark
+                .kind(aho_corasick::AhoCorasickKind::DFA) // DFA results in faster matches
                 .match_kind(matchkind)
                 .build(patterns.chunks(10 * 1024).flat_map(|chunk| {
                     let result = chunk

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@ struct PyAhoCorasick {
 /// Convert a MatchError to something meaningful to Python users
 #[cold]
 fn match_error_to_pyerror(e: MatchError) -> PyErr {
-    // TODO make sure this error is still meaningful to Python
-    // users, otherwise need to customize it
     PyValueError::new_err(e.to_string())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl PyAhoCorasick {
         Ok(Self {
             ac_impl: AhoCorasickBuilder::new()
                 // TODO consider noncontiguous, and/or auto mode; need to benchmark
-                .kind(aho_corasick::AhoCorasickKind::DFA) // DFA results in faster matches
+                .kind(Some(aho_corasick::AhoCorasickKind::DFA)) // DFA results in faster matches
                 .match_kind(matchkind)
                 .build(patterns.chunks(10 * 1024).flat_map(|chunk| {
                     let result = chunk

--- a/tests/test_ac.py
+++ b/tests/test_ac.py
@@ -10,15 +10,21 @@ from ahocorasick_rs import (
     MATCHKIND_STANDARD,
     MATCHKIND_LEFTMOST_FIRST,
     MATCHKIND_LEFTMOST_LONGEST,
-    KIND_NONCONTIGUOUS_NFA,
-    KIND_CONTIGUOUS_NFA,
-    KIND_DFA,
+    Implementation,
 )
 
 
 @pytest.mark.parametrize("store_patterns", [True, False, None])
-@pytest.mark.parametrize("kind", [None, KIND_NONCONTIGUOUS_NFA, KIND_CONTIGUOUS_NFA, KIND_DFA])
-def test_basic_matching(store_patterns, kind):
+@pytest.mark.parametrize(
+    "implementation",
+    [
+        None,
+        Implementation.NoncontiguousNFA,
+        Implementation.ContiguousNFA,
+        Implementation.DFA,
+    ],
+)
+def test_basic_matching(store_patterns, implementation):
     """
     find_matches_as_indexes() and find_matches_as_strings() return matching
     patterns in the given string.
@@ -28,7 +34,9 @@ def test_basic_matching(store_patterns, kind):
     if store_patterns is None:
         ac = AhoCorasick(patterns)
     else:
-        ac = AhoCorasick(patterns, store_patterns=store_patterns, kind=kind)
+        ac = AhoCorasick(
+            patterns, store_patterns=store_patterns, implementation=implementation
+        )
 
     expected = ["hello", "world", "hello"]
 
@@ -42,8 +50,16 @@ def test_basic_matching(store_patterns, kind):
 
 
 @pytest.mark.parametrize("store_patterns", [True, False, None])
-@pytest.mark.parametrize("kind", [None, KIND_NONCONTIGUOUS_NFA, KIND_CONTIGUOUS_NFA, KIND_DFA])
-def test_unicode(store_patterns, kind):
+@pytest.mark.parametrize(
+    "implementation",
+    [
+        None,
+        Implementation.NoncontiguousNFA,
+        Implementation.ContiguousNFA,
+        Implementation.DFA,
+    ],
+)
+def test_unicode(store_patterns, implementation):
     """
     Non-ASCII unicode patterns still give correct results for
     find_matches_as_indexes() and find_matches_as_strings().
@@ -53,7 +69,9 @@ def test_unicode(store_patterns, kind):
     if store_patterns is None:
         ac = AhoCorasick(patterns)
     else:
-        ac = AhoCorasick(patterns, store_patterns=store_patterns, kind=kind)
+        ac = AhoCorasick(
+            patterns, store_patterns=store_patterns, implementation=implementation
+        )
     index_matches = ac.find_matches_as_indexes(haystack)
     expected = ["d ☃f", "há", "l🤦l"]
     assert [patterns[i] for (i, _, _) in index_matches] == expected

--- a/tests/test_ac.py
+++ b/tests/test_ac.py
@@ -10,11 +10,15 @@ from ahocorasick_rs import (
     MATCHKIND_STANDARD,
     MATCHKIND_LEFTMOST_FIRST,
     MATCHKIND_LEFTMOST_LONGEST,
+    KIND_NONCONTIGUOUS_NFA,
+    KIND_CONTIGUOUS_NFA,
+    KIND_DFA,
 )
 
 
 @pytest.mark.parametrize("store_patterns", [True, False, None])
-def test_basic_matching(store_patterns):
+@pytest.mark.parametrize("kind", [None, KIND_NONCONTIGUOUS_NFA, KIND_CONTIGUOUS_NFA, KIND_DFA])
+def test_basic_matching(store_patterns, kind):
     """
     find_matches_as_indexes() and find_matches_as_strings() return matching
     patterns in the given string.
@@ -24,7 +28,7 @@ def test_basic_matching(store_patterns):
     if store_patterns is None:
         ac = AhoCorasick(patterns)
     else:
-        ac = AhoCorasick(patterns, store_patterns=store_patterns)
+        ac = AhoCorasick(patterns, store_patterns=store_patterns, kind=kind)
 
     expected = ["hello", "world", "hello"]
 
@@ -38,7 +42,8 @@ def test_basic_matching(store_patterns):
 
 
 @pytest.mark.parametrize("store_patterns", [True, False, None])
-def test_unicode(store_patterns):
+@pytest.mark.parametrize("kind", [None, KIND_NONCONTIGUOUS_NFA, KIND_CONTIGUOUS_NFA, KIND_DFA])
+def test_unicode(store_patterns, kind):
     """
     Non-ASCII unicode patterns still give correct results for
     find_matches_as_indexes() and find_matches_as_strings().
@@ -48,7 +53,7 @@ def test_unicode(store_patterns):
     if store_patterns is None:
         ac = AhoCorasick(patterns)
     else:
-        ac = AhoCorasick(patterns, store_patterns=store_patterns)
+        ac = AhoCorasick(patterns, store_patterns=store_patterns, kind=kind)
     index_matches = ac.find_matches_as_indexes(haystack)
     expected = ["d ☃f", "há", "l🤦l"]
     assert [patterns[i] for (i, _, _) in index_matches] == expected


### PR DESCRIPTION
Changes based on the branch `50-port-to-ahocorasick-rs-v10`:
* daa757f1ca252eedbb491f7e5f79fe2bfb578062 : Related to #50 : update to support aho_corasick version 1.0.0
*  9689529c4163d54776fff587bddf1d05de561e48 : Related to #53 : add a new `kind` parameter. All the possible values are exposed: `KIND_NONCONTIGUOUS_NFA`, `KIND_CONTIGUOUS_NFA`, `KIND_DFA`, `None`.
* 6b6bbffef8148f85cc88ec173199a6ff0bdd7909 : add documentation about the `kind` parameter in `README.md`. I'm not sure about my wording.


Feel free to use this PR, these commits or not (I think this is my first PR on a Rust project).

