### PR TITLE
Fix documentation examples and setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ Thank you for considering contributing! Note that by contributing your code, you
 
 First, download and install [Just](https://github.com/casey/just)
 
-Then, setup a virtualenv, install dev dependencies, and compile the code:
+Then, set up a virtualenv, install dev dependencies, and compile the code:
 
 ```bash
 just setup
-source venv/bin/activateo  # or Windoes equivalent
+source venv/bin/activate  # or Windows equivalent
 just build-dev
 ```
 
@@ -25,6 +25,6 @@ $ just test
 To run benchmarks:
 
 ```shell-session
-$ just prep-benchmark  # on Linux Intel, disables turbobost
+$ just prep-benchmark  # on Linux Intel, disables Turbo Boost
 $ just benchmark
 ```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This returns the pattern that matches first, semantically-speaking.
 This is the default matching pattern.
 
 ```python
->>> ac AhoCorasick(["disco", "disc", "discontent"])
+>>> ac = AhoCorasick(["disco", "disc", "discontent"])
 >>> ac.find_matches_as_strings("discontent")
 ['disc']
 >>> ac = AhoCorasick(["b", "abcd"])
@@ -128,6 +128,7 @@ That means the order of patterns makes a difference:
 >>> ac.find_matches_as_strings("discontent")
 ['disco']
 >>> ac = AhoCorasick(["disc", "disco"], matchkind=MatchKind.LeftmostFirst)
+>>> ac.find_matches_as_strings("discontent")
 ['disc']
 ```
 
@@ -138,7 +139,7 @@ Here we see `abcd` matched first, because it starts before `b`:
 >>> ac.find_matches_as_strings("abcdef")
 ['abcd']
 ```
-##### `LeftmostLongest`
+#### `LeftmostLongest`
 
 This returns the leftmost-in-the-haystack matching pattern that is longest:
 


### PR DESCRIPTION
## Summary

- fix the contributor virtualenv activation command and nearby setup typos
- repair a malformed `AhoCorasick` assignment in the README examples
- restore the missing method call in the `LeftmostFirst` example
- align the `LeftmostLongest` heading with the other match-kind sections

## Validation

- `git diff --check`
- confirmed `justfile` creates the documented `venv` directory
- checked that the broken command, typo, malformed assignment, and heading tokens no longer appear
